### PR TITLE
Global logger

### DIFF
--- a/sewer/__init__.py
+++ b/sewer/__init__.py
@@ -1,12 +1,12 @@
 from .client import Client  # noqa: F401
-
-from .dns_providers import BaseDns  # noqa: F401
-from .dns_providers import AuroraDns  # noqa: F401
-from .dns_providers import CloudFlareDns  # noqa: F401
 from .dns_providers import AcmeDnsDns  # noqa: F401
 from .dns_providers import AliyunDns  # noqa:F401
-from .dns_providers import HurricaneDns  # noqa:F401
-from .dns_providers import RackspaceDns  # noqa:F401
+from .dns_providers import AuroraDns  # noqa: F401
+from .dns_providers import BaseDns  # noqa: F401
+from .dns_providers import CloudFlareDns  # noqa: F401
+from .dns_providers import ClouDNSDns  # noqa:F401
 from .dns_providers import DNSPodDns  # noqa:F401
 from .dns_providers import DuckDNSDns  # noqa:F401
-from .dns_providers import ClouDNSDns  # noqa:F401
+from .dns_providers import HurricaneDns  # noqa:F401
+from .dns_providers import RackspaceDns  # noqa:F401
+from .log import set_logger  # noqa: F401

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -1,18 +1,18 @@
-import time
-import copy
-import json
 import base64
-import hashlib
-import logging
 import binascii
+import copy
+import hashlib
+import json
 import platform
+import time
 
-import requests
-import OpenSSL
 import cryptography
+import OpenSSL
+import requests
 
 from . import __version__ as sewer_version
 from .config import ACME_DIRECTORY_URL_PRODUCTION
+from .log import get_logger
 
 
 class Client(object):
@@ -147,12 +147,7 @@ class Client(object):
         self.ACME_DIRECTORY_URL = ACME_DIRECTORY_URL
         self.LOG_LEVEL = LOG_LEVEL.upper()
 
-        self.logger = logging.getLogger("sewer")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter("%(message)s")
-        handler.setFormatter(formatter)
-        if not self.logger.handlers:
-            self.logger.addHandler(handler)
+        self.logger = get_logger()
         self.logger.setLevel(self.LOG_LEVEL)
 
         try:

--- a/sewer/dns_providers/common.py
+++ b/sewer/dns_providers/common.py
@@ -1,4 +1,4 @@
-import logging
+from ..log import get_logger
 
 
 class BaseDns(object):
@@ -9,12 +9,7 @@ class BaseDns(object):
         self.LOG_LEVEL = LOG_LEVEL
         self.dns_provider_name = self.__class__.__name__
 
-        self.logger = logging.getLogger("sewer")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter("%(message)s")
-        handler.setFormatter(formatter)
-        if not self.logger.handlers:
-            self.logger.addHandler(handler)
+        self.logger = get_logger()
         self.logger.setLevel(self.LOG_LEVEL)
 
     def log_response(self, response):

--- a/sewer/log.py
+++ b/sewer/log.py
@@ -1,0 +1,27 @@
+import logging
+
+_logger = None
+
+
+def _default_logger():
+    logger = logging.getLogger("sewer")
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+    if not logger.handlers:
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    return logger
+
+
+def set_logger(logger):
+    global _logger
+    _logger = logger
+
+
+def get_logger():
+    return _logger
+
+
+set_logger(_default_logger())


### PR DESCRIPTION
Thank you for contributing to sewer.                    
Every contribution to sewer is important to us.                       
You may not know it, but you have just contributed to making the world a more safer and secure place.                         

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to sewer, and sewer agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that sewer shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

## What(What have you changed?)
Made logger a global that gets imported into all the classes that want it.

## Why(Why did you change it?)
Setting up the logger in multiple places causes lines to be printed twice and the user can set up their own logger and have sewer use it.